### PR TITLE
Fix Dry::Types deprecations

### DIFF
--- a/lib/loqate/address/address.rb
+++ b/lib/loqate/address/address.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Address
     # A result from the address find service.
-    class Address < Dry::Struct::Value
+    class Address < Dry::Struct
       # An address ID or a container ID for further results
       #
       # @return [String]

--- a/lib/loqate/bank/account_validation.rb
+++ b/lib/loqate/bank/account_validation.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Bank
     # Result of a bank account validation.
-    class AccountValidation < Dry::Struct::Value
+    class AccountValidation < Dry::Struct
       StatusInformation = Types::Strict::String.enum('DetailsChanged', 'CautiousOK')
 
       # Indicates whether the account number and sortcode are valid.

--- a/lib/loqate/bank/batch_account_validation.rb
+++ b/lib/loqate/bank/batch_account_validation.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Bank
     # Result of a batch bank account validation.
-    class BatchAccountValidation < Dry::Struct::Value
+    class BatchAccountValidation < Dry::Struct
       StatusInformation = Types::Strict::String.enum('CautiousOK', 'DetailsChanged', 'OK')
 
       # The original AccountNumber passed to validate, excluding any non numeric characters.

--- a/lib/loqate/bank/branch.rb
+++ b/lib/loqate/bank/branch.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Bank
     # Result of a bank branch retrieval.
-    class Branch < Dry::Struct::Value
+    class Branch < Dry::Struct
       # The name of the banking institution.
       #
       # @return [String]

--- a/lib/loqate/bank/card_validation.rb
+++ b/lib/loqate/bank/card_validation.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Bank
     # Result of a card validation.
-    class CardValidation < Dry::Struct::Value
+    class CardValidation < Dry::Struct
       # The cleaned card number.
       #
       # @return [String]

--- a/lib/loqate/bank/international_account_validation.rb
+++ b/lib/loqate/bank/international_account_validation.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Bank
     # Result of an international bank account validation.
-    class InternationalAccountValidation < Dry::Struct::Value
+    class InternationalAccountValidation < Dry::Struct
       # Indicates whether the account number and sortcode are valid.
       #
       # @return [Boolean]

--- a/lib/loqate/email/batch_email_validation.rb
+++ b/lib/loqate/email/batch_email_validation.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Email
     # Result of a batch email address validation.
-    class BatchEmailValidation < Dry::Struct::Value
+    class BatchEmailValidation < Dry::Struct
       Status = Types::Strict::String.enum('Valid', 'Invalid', 'Unknown', 'Accept_All')
 
       # Valid - The email address is valid

--- a/lib/loqate/email/email_validation.rb
+++ b/lib/loqate/email/email_validation.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Email
     # Result of a email address validation.
-    class EmailValidation < Dry::Struct::Value
+    class EmailValidation < Dry::Struct
       ResponseCode = Types::Strict::String.enum('Valid', 'Valid_CatchAll', 'Invalid', 'Timeout')
 
       # Valid - The email address has been fully validated (including the account portion)

--- a/lib/loqate/geocoding/country.rb
+++ b/lib/loqate/geocoding/country.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Geocoding
     # A result from the position to country API call.
-    class Country < Dry::Struct::Value
+    class Country < Dry::Struct
       # The name of the country where the position belongs to.
       #
       # @return [String]

--- a/lib/loqate/geocoding/direction.rb
+++ b/lib/loqate/geocoding/direction.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Geocoding
     # A result from the directions API call.
-    class Direction < Dry::Struct::Value
+    class Direction < Dry::Struct
       # A zero based counter indicating the row number.
       #
       # @return [Integer]

--- a/lib/loqate/geocoding/location.rb
+++ b/lib/loqate/geocoding/location.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Geocoding
     # A result from the geocode API call.
-    class Location < Dry::Struct::Value
+    class Location < Dry::Struct
       # The name of the location found.
       #
       # @return [String]

--- a/lib/loqate/geocoding/place.rb
+++ b/lib/loqate/geocoding/place.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Geocoding
     # A result from the API call to find the nearest places.
-    class Place < Dry::Struct::Value
+    class Place < Dry::Struct
       # The postcode that is nearest to the given location.
       #
       # @return [String]

--- a/lib/loqate/phone/phone_number_validation.rb
+++ b/lib/loqate/phone/phone_number_validation.rb
@@ -1,7 +1,7 @@
 module Loqate
   module Phone
     # Result of a phone number validation.
-    class PhoneNumberValidation < Dry::Struct::Value
+    class PhoneNumberValidation < Dry::Struct
       IsValid = Types::Strict::String.enum('Yes', 'No', 'Unknown')
       NumberType = Types::Strict::String.enum('Mobile', 'Landline', 'Voip', 'Unknown')
 

--- a/lib/loqate/types.rb
+++ b/lib/loqate/types.rb
@@ -4,6 +4,6 @@ require 'dry/struct'
 module Loqate
   # Dry-types container.
   module Types
-    include Dry::Types.module
+    include Dry.Types()
   end
 end

--- a/loqate.gemspec
+++ b/loqate.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-struct', '~> 1.0'
   spec.add_runtime_dependency 'http', '~> 4.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'bundler-audit', '~> 0.6'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-bundler', '~> 2.1'

--- a/spec/loqate/result/mixin_spec.rb
+++ b/spec/loqate/result/mixin_spec.rb
@@ -1,11 +1,13 @@
 require 'loqate/result'
 
 RSpec.describe Loqate::Result::Mixin do
-  class ExampleAction
-    include Loqate::Result::Mixin
-  end
+  subject(:action) { klass.new }
 
-  let(:action) { ExampleAction.new }
+  let(:klass) do
+    Class.new do
+      include Loqate::Result::Mixin
+    end
+  end
 
   describe '#Failure' do
     it 'returns a failure result' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require 'webmock/rspec'
 require 'pry'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in spec/support/ and its subdirectories.
-Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].sort.each { |file| require file }
 
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
Addresses the following deprecation warnings:

```ruby
[dry-types] Dry::Types.module is deprecated and will be removed in the next major version
Use Dry.Types() instead. Beware, it exports strict types by default, for old behavior use Dry.Types(default: :nominal). See more options in the changelog
```

```
[dry-struct] Dry::Struct::Value is deprecated and will be removed in the next major version
```

**Also:**

- Relaxes the `bundler` version dependency for development to allow for more recent versions to be used