### PR TITLE
Address ruby 2.7 deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,15 +3,17 @@ require: rubocop-rspec
 AllCops:
   DisplayCopNames: true
 
+# ---------------------- Layout -----------------------
+
+Layout/LineLength:
+  Max: 120
+
 # ---------------------- Metrics ----------------------
 
 Metrics/BlockLength:
   Exclude:
     - spec/**/*_spec.rb
     - loqate.gemspec
-
-Metrics/LineLength:
-  Max: 120
 
 Naming/MethodName:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ env:
     - CC_TEST_REPORTER_ID=b25183239ab212ebe6b73b13e25fe32ff06b542836e2e1d8786fa8966954b63f
 
 rvm:
-  - 2.5.1
+  - 2.5
+  - 2.6
+  - 2.7
+  - jruby
 
 before_install: gem install bundler -v 1.16.5
 

--- a/lib/loqate/gateway.rb
+++ b/lib/loqate/gateway.rb
@@ -22,8 +22,8 @@ module Loqate
     #
     # @see Configuration
     #
-    def initialize(options)
-      @config = Configuration.new(options)
+    def initialize(**options)
+      @config = Configuration.new(**options)
       @client = Client.new(config)
     end
 

--- a/lib/loqate/mappers/error_mapper.rb
+++ b/lib/loqate/mappers/error_mapper.rb
@@ -25,7 +25,7 @@ module Loqate
         attributes = item.transform_keys { |attribute| Util.underscore(attribute) }
         attributes[:id] = attributes.delete(:error).to_i
 
-        Loqate::Error.new(attributes)
+        Loqate::Error.new(**attributes)
       end
     end
   end

--- a/loqate.gemspec
+++ b/loqate.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.59'
+  spec.add_development_dependency 'rubocop', '~> 0.78'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.29'
   spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'simplecov-console', '~> 0.4'


### PR DESCRIPTION
  When using ruby 2.7 we get the following warnings:

```
loqate/lib/loqate/mappers/error_mapper.rb:28: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
loqate/lib/loqate/error.rb:35: warning: The called method `initialize' is defined here
loqate/lib/loqate/gateway.rb:26: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
loqate/lib/loqate/configuration.rb:28: warning: The called method `initialize' is defined here
```

More info [here](https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/)

**Also:**
- Update TravisCI matrix to run with different ruby versions for better assertion of compatibility
- Update  Rubocop namespace for LineLength

    ```ruby
    .rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
    ```