### PR TITLE
Update HTTP gem version dependency

### DIFF
--- a/loqate.gemspec
+++ b/loqate.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'dry-struct', '~> 1.0'
-  spec.add_runtime_dependency 'http', '~> 4.0.0'
+  spec.add_runtime_dependency 'http', '>= 4.3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'bundler-audit', '~> 0.6'


### PR DESCRIPTION
The version currently in use has an incompatibility with Ruby 2.7: https://github.com/httprb/http/issues/582

The earliest version with a fix for this is 4.3.0 (as per noted here:
https://github.com/elastic/apm-agent-ruby/issues/665#issuecomment-572664916)