### PR TITLE
Update EmailValidation schema

### DIFF
--- a/lib/loqate/email/email_validation.rb
+++ b/lib/loqate/email/email_validation.rb
@@ -44,13 +44,6 @@ module Loqate
       #
       attribute :is_disposable_or_temporary, Types::Strict::Bool
 
-      # True if we recognise the email address against known lists of complainers and/or the email address has been
-      # used to defraud.
-      #
-      # @return [Boolean]
-      #
-      attribute :is_complainer_or_fraud_risk, Types::Strict::Bool
-
       # The duration (in seconds) that the email validation took (maximum timeout enforced at 15 seconds).
       # We recommend a high timeout (at least 5 seconds) value as it will minimise the number of "Timeout"
       # responses returned.

--- a/lib/loqate/email/email_validation.rb
+++ b/lib/loqate/email/email_validation.rb
@@ -57,7 +57,7 @@ module Loqate
       #
       # @return [Float]
       #
-      attribute :duration, Types::Strict::Float
+      attribute :duration, Types::Coercible::Float
 
       # Whether the email was fully validated (including the account portion).
       def valid?

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate/when_invoked_with_a_list_of_emails/returns_multiple_validation_results.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate/when_invoked_with_a_list_of_emails/returns_multiple_validation_results.yml
@@ -14,16 +14,16 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Sat, 17 Nov 2018 11:04:58 GMT
+      - Thu, 21 Jan 2021 15:22:14 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
@@ -42,8 +42,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '3'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -51,7 +49,8 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CLWcg_iLupeGQg; path=/; HttpOnly; expires=Sat, 17-Nov-2018 11:05:57 GMT
+      - GCLB=CIWskI7Xo_2m4AE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:13
+        GMT
       Alt-Svc:
       - clear
       Connection:
@@ -59,6 +58,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"Items":[{"Status":"Invalid","EmailAddress":"not_an_email","Account":"","Domain":"","IsDisposible":false,"IsSystemMailbox":false},{"Status":"Valid","EmailAddress":"contact@wilsonsilva.net","Account":"contact","Domain":"wilsonsilva.net","IsDisposible":false,"IsSystemMailbox":true},{"Status":"Unknown","EmailAddress":"temp@dispostable.com","Account":"temp","Domain":"dispostable.com","IsDisposible":true,"IsSystemMailbox":false}]}'
-    http_version: 
-  recorded_at: Sat, 17 Nov 2018 11:04:58 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Thu, 21 Jan 2021 15:22:14 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate/when_invoked_without_a_list_of_emails/returns_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate/when_invoked_without_a_list_of_emails/returns_an_error.yml
@@ -14,16 +14,16 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Sat, 17 Nov 2018 11:04:57 GMT
+      - Thu, 21 Jan 2021 15:22:13 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
@@ -38,8 +38,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -47,7 +45,8 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CN2x-qH61b2pTw; path=/; HttpOnly; expires=Sat, 17-Nov-2018 11:05:57 GMT
+      - GCLB=CNOP36qx_vnx4AE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:13
+        GMT
       Alt-Svc:
       - clear
       Connection:
@@ -57,6 +56,5 @@ http_interactions:
       string: '{"Items":[{"Error":"1001","Description":"Emails Required","Cause":"No
         email addresses were supplied.","Resolution":"Check that you have betweeon
         1 and 100 emails in the batch and try again."}]}'
-    http_version: 
-  recorded_at: Sat, 17 Nov 2018 11:04:57 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Thu, 21 Jan 2021 15:22:13 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate_/when_the_result_is_not_successful/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate_/when_the_result_is_not_successful/raises_an_error.yml
@@ -2,66 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.addressy.com/EmailValidation/Interactive/Validate/v2.00/json3.ws?Emailee=whatevz&Key=<LOQATE_API_KEY>
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Host:
-      - api.addressy.com
-      User-Agent:
-      - http.rb/4.0.0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.10.3 (Ubuntu)
-      Date:
-      - Sat, 17 Nov 2018 11:10:36 GMT
-      Content-Type:
-      - application/json;charset=UTF-8
-      Content-Length:
-      - '174'
-      Vary:
-      - Accept-Encoding
-      Cache-Control:
-      - private
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Content-Type, pca-source
-      Records:
-      - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Xss-Protection:
-      - '1'
-      X-Robots-Tag:
-      - noindex
-      Via:
-      - 1.1 google
-      Set-Cookie:
-      - GCLB=CIipop7v3rX7vQE; path=/; HttpOnly; expires=Sat, 17-Nov-2018 11:11:36
-        GMT
-      Alt-Svc:
-      - clear
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"Items":[{"Error":"1001","Description":"Email Required","Cause":"The
-        Email is required.","Resolution":"Please ensure that you supply a valid Email
-        address and try again."}]}'
-    http_version: 
-  recorded_at: Sat, 17 Nov 2018 11:10:36 GMT
-- request:
-    method: get
     uri: https://api.addressy.com/EmailValidation/Batch/Validate/v1.20/json3.ws?Emailees=whatevz&Key=<LOQATE_API_KEY>
     body:
       encoding: UTF-8
@@ -74,16 +14,16 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Sat, 17 Nov 2018 11:12:20 GMT
+      - Thu, 21 Jan 2021 15:22:15 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
@@ -98,8 +38,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -107,7 +45,7 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CK6IroeNzbOgkQE; path=/; HttpOnly; expires=Sat, 17-Nov-2018 11:13:20
+      - GCLB=CLbAs-6075jOrQE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:15
         GMT
       Alt-Svc:
       - clear
@@ -118,6 +56,5 @@ http_interactions:
       string: '{"Items":[{"Error":"1001","Description":"Emails Required","Cause":"No
         email addresses were supplied.","Resolution":"Check that you have betweeon
         1 and 100 emails in the batch and try again."}]}'
-    http_version: 
-  recorded_at: Sat, 17 Nov 2018 11:12:20 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Thu, 21 Jan 2021 15:22:15 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate_/when_the_result_is_successful/returns_the_unwrapped_result.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_batch_validate_/when_the_result_is_successful/returns_the_unwrapped_result.yml
@@ -14,16 +14,16 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Sat, 17 Nov 2018 11:10:36 GMT
+      - Thu, 21 Jan 2021 15:22:15 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
@@ -42,8 +42,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -51,8 +49,7 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CPPg3r6R5o_dqAE; path=/; HttpOnly; expires=Sat, 17-Nov-2018 11:11:36
-        GMT
+      - GCLB=CNa9yPvqs8KGPA; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:14 GMT
       Alt-Svc:
       - clear
       Connection:
@@ -60,6 +57,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"Items":[{"Status":"Valid","EmailAddress":"contact@wilsonsilva.net","Account":"contact","Domain":"wilsonsilva.net","IsDisposible":false,"IsSystemMailbox":true}]}'
-    http_version: 
-  recorded_at: Sat, 17 Nov 2018 11:10:36 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Thu, 21 Jan 2021 15:22:15 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_invoked_without_an_email/returns_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_invoked_without_an_email/returns_an_error.yml
@@ -14,16 +14,16 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Fri, 16 Nov 2018 08:34:56 GMT
+      - Thu, 21 Jan 2021 15:22:15 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
@@ -38,8 +38,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -47,8 +45,7 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CJaelNCKo6DQwQE; path=/; HttpOnly; expires=Fri, 16-Nov-2018 13:52:40
-        GMT
+      - GCLB=CJq7wMblnPL_cQ; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:15 GMT
       Alt-Svc:
       - clear
       Connection:
@@ -58,6 +55,5 @@ http_interactions:
       string: '{"Items":[{"Error":"1001","Description":"Email Required","Cause":"The
         Email is required.","Resolution":"Please ensure that you supply a valid Email
         address and try again."}]}'
-    http_version:
-  recorded_at: Fri, 16 Nov 2018 08:34:56 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Thu, 21 Jan 2021 15:22:15 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_only_the_email_domain_was_validated/returns_a_partially_valid_email_validation.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_only_the_email_domain_was_validated/returns_a_partially_valid_email_validation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.addressy.com/EmailValidation/Interactive/Validate/v2.00/json3.ws?Email=contact@wilsonsilva.net&Key=<LOQATE_API_KEY>
+    uri: https://api.addressy.com/EmailValidation/Interactive/Validate/v2.00/json3.ws?Email=support@google.com&Key=<LOQATE_API_KEY>
     body:
       encoding: UTF-8
       string: ''
@@ -14,20 +14,20 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Fri, 16 Nov 2018 08:34:56 GMT
+      - Thu, 21 Jan 2021 15:22:16 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '300'
+      - '258'
       Vary:
       - Accept-Encoding
       Cache-Control:
@@ -42,8 +42,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -51,7 +49,7 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CNuQ66yzqt_68AE; path=/; HttpOnly; expires=Fri, 16-Nov-2018 12:24:56
+      - GCLB=CKa_76WD9uznuAE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:16
         GMT
       Alt-Svc:
       - clear
@@ -60,6 +58,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"Items":[{"ResponseCode":"Valid_CatchAll","ResponseMessage":"Mail
-        is routable to the domain but account could not be validated","EmailAddress":"contact@wilsonsilva.net","UserAccount":"contact","Domain":"wilsonsilva.net","IsDisposableOrTemporary":false,"IsComplainerOrFraudRisk":false,"Duration":0.241566504}]}'
-    http_version:
-  recorded_at: Fri, 16 Nov 2018 08:34:56 GMT
+        is routable to the domain but account could not be validated","EmailAddress":"support@google.com","UserAccount":"support","Domain":"google.com","IsDisposableOrTemporary":false,"Duration":0}]}'
+  recorded_at: Thu, 21 Jan 2021 15:22:16 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_the_email_is_invalid/returns_an_invalid_email_validation.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_the_email_is_invalid/returns_an_invalid_email_validation.yml
@@ -14,20 +14,20 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Fri, 16 Nov 2018 08:34:56 GMT
+      - Thu, 21 Jan 2021 15:22:17 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '238'
+      - '196'
       Vary:
       - Accept-Encoding
       Cache-Control:
@@ -42,8 +42,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -51,7 +49,7 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CNu4h5rdp-Xp-gE; path=/; HttpOnly; expires=Fri, 16-Nov-2018 13:52:42
+      - GCLB=CIu83bmhm8HDvwE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:16
         GMT
       Alt-Svc:
       - clear
@@ -60,7 +58,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"Items":[{"ResponseCode":"Invalid","ResponseMessage":"Email Address
-        is not valid","EmailAddress":"404@404.pl","UserAccount":"404","Domain":"404.pl","IsDisposableOrTemporary":false,"IsComplainerOrFraudRisk":false,"Duration":0.009907195}]}'
-    http_version:
-  recorded_at: Fri, 16 Nov 2018 08:34:56 GMT
-recorded_with: VCR 4.0.0
+        is not valid","EmailAddress":"404@404.pl","UserAccount":"404","Domain":"404.pl","IsDisposableOrTemporary":false,"Duration":0}]}'
+  recorded_at: Thu, 21 Jan 2021 15:22:17 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_the_email_is_valid/returns_a_valid_email_validation.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate/when_the_email_is_valid/returns_a_valid_email_validation.yml
@@ -14,20 +14,20 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Fri, 16 Nov 2018 08:34:56 GMT
+      - Thu, 21 Jan 2021 15:22:16 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '267'
+      - '225'
       Vary:
       - Accept-Encoding
       Cache-Control:
@@ -42,8 +42,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -51,7 +49,7 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=COXLsfD6pOuH2gE; path=/; HttpOnly; expires=Fri, 16-Nov-2018 13:52:40
+      - GCLB=CNGb89CqvtSUlgE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:16
         GMT
       Alt-Svc:
       - clear
@@ -60,7 +58,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"Items":[{"ResponseCode":"Valid","ResponseMessage":"Email address
-        was fully validated","EmailAddress":"wilson.silva@gmail.com","UserAccount":"wilson.silva","Domain":"gmail.com","IsDisposableOrTemporary":false,"IsComplainerOrFraudRisk":false,"Duration":0.007366261}]}'
-    http_version:
-  recorded_at: Fri, 16 Nov 2018 08:34:56 GMT
-recorded_with: VCR 4.0.0
+        was fully validated","EmailAddress":"wilson.silva@gmail.com","UserAccount":"wilson.silva","Domain":"gmail.com","IsDisposableOrTemporary":false,"Duration":0}]}'
+  recorded_at: Thu, 21 Jan 2021 15:22:16 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate_/when_the_result_is_not_successful/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate_/when_the_result_is_not_successful/raises_an_error.yml
@@ -14,16 +14,16 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Fri, 16 Nov 2018 08:34:56 GMT
+      - Thu, 21 Jan 2021 15:22:18 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
@@ -38,8 +38,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -47,7 +45,8 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CMbskOnSvKm7fQ; path=/; HttpOnly; expires=Fri, 16-Nov-2018 13:52:43 GMT
+      - GCLB=CMLr07n05Ir8oQE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:18
+        GMT
       Alt-Svc:
       - clear
       Connection:
@@ -57,6 +56,5 @@ http_interactions:
       string: '{"Items":[{"Error":"1001","Description":"Email Required","Cause":"The
         Email is required.","Resolution":"Please ensure that you supply a valid Email
         address and try again."}]}'
-    http_version:
-  recorded_at: Fri, 16 Nov 2018 08:34:56 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Thu, 21 Jan 2021 15:22:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate_/when_the_result_is_successful/returns_the_unwrapped_result.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Email_Gateway/_validate_/when_the_result_is_successful/returns_the_unwrapped_result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.addressy.com/EmailValidation/Interactive/Validate/v2.00/json3.ws?Email=contact@wilsonsilva.net&Key=<LOQATE_API_KEY>
+    uri: https://api.addressy.com/EmailValidation/Interactive/Validate/v2.00/json3.ws?Email=support@google.com&Key=<LOQATE_API_KEY>
     body:
       encoding: UTF-8
       string: ''
@@ -14,20 +14,20 @@ http_interactions:
       Host:
       - api.addressy.com
       User-Agent:
-      - http.rb/4.0.0
+      - http.rb/4.4.1
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.10.3 (Ubuntu)
+      - nginx/1.14.0 (Ubuntu)
       Date:
-      - Fri, 16 Nov 2018 08:34:56 GMT
+      - Thu, 21 Jan 2021 15:22:18 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '300'
+      - '258'
       Vary:
       - Accept-Encoding
       Cache-Control:
@@ -42,8 +42,6 @@ http_interactions:
       - Content-Type, pca-source
       Records:
       - '1'
-      X-Aspnet-Version:
-      - 4.0.30319
       X-Xss-Protection:
       - '1'
       X-Robots-Tag:
@@ -51,7 +49,7 @@ http_interactions:
       Via:
       - 1.1 google
       Set-Cookie:
-      - GCLB=CNuQ66yzqt_68AE; path=/; HttpOnly; expires=Fri, 16-Nov-2018 08:34:56
+      - GCLB=COzayu33noCxswE; path=/; HttpOnly; expires=Thu, 21-Jan-2021 15:23:17
         GMT
       Alt-Svc:
       - clear
@@ -60,6 +58,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"Items":[{"ResponseCode":"Valid_CatchAll","ResponseMessage":"Mail
-        is routable to the domain but account could not be validated","EmailAddress":"contact@wilsonsilva.net","UserAccount":"contact","Domain":"wilsonsilva.net","IsDisposableOrTemporary":false,"IsComplainerOrFraudRisk":false,"Duration":0.241566504}]}'
-    http_version:
-  recorded_at: Fri, 16 Nov 2018 08:34:56 GMT
+        is routable to the domain but account could not be validated","EmailAddress":"support@google.com","UserAccount":"support","Domain":"google.com","IsDisposableOrTemporary":false,"Duration":0}]}'
+  recorded_at: Thu, 21 Jan 2021 15:22:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/loqate/email/email_validation_spec.rb
+++ b/spec/loqate/email/email_validation_spec.rb
@@ -1,6 +1,7 @@
 require 'loqate/email/email_validation'
 
 RSpec.describe Loqate::Email::EmailValidation do
+  let(:duration) { 0.241566504 }
   let(:attributes) do
     {
       response_code: 'Valid',
@@ -10,10 +11,36 @@ RSpec.describe Loqate::Email::EmailValidation do
       domain: 'wilsonsilva.net',
       is_disposable_or_temporary: false,
       is_complainer_or_fraud_risk: false,
-      duration: 0.241566504
+      duration: duration
     }
   end
   let(:email_validation) { described_class.new(attributes) }
+
+  describe 'attributes coercion' do
+    context 'when the duration cannot be coerced into a float' do
+      let(:duration) { 'not-a-coercible-float' }
+
+      it 'raises an error' do
+        expect { email_validation }.to raise_error(Dry::Struct::Error, /invalid type for :duration/)
+      end
+    end
+
+    context 'when the duration is an integer' do
+      let(:duration) { 1 }
+
+      it 'coerces the duration into a float' do
+        expect(email_validation.duration).to eq(1.0)
+      end
+    end
+
+    context 'when the duration is a string' do
+      let(:duration) { '0.367289412' }
+
+      it 'coerces the duration into a float' do
+        expect(email_validation.duration).to eq(0.367289412)
+      end
+    end
+  end
 
   describe '#response_code' do
     it 'exposes the validity of the email' do
@@ -59,7 +86,7 @@ RSpec.describe Loqate::Email::EmailValidation do
 
   describe '#duration' do
     it 'exposes the duration (in seconds) that the email validation took' do
-      expect(email_validation.duration).to eq(0.241566504)
+      expect(email_validation.duration).to eq(duration)
     end
   end
 

--- a/spec/loqate/email/email_validation_spec.rb
+++ b/spec/loqate/email/email_validation_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Loqate::Email::EmailValidation do
       user_account: 'contact',
       domain: 'wilsonsilva.net',
       is_disposable_or_temporary: false,
-      is_complainer_or_fraud_risk: false,
       duration: duration
     }
   end
@@ -75,12 +74,6 @@ RSpec.describe Loqate::Email::EmailValidation do
   describe '#is_disposable_or_temporary' do
     it 'exposes whether the email address provided is a disposable mailbox' do
       expect(email_validation.is_disposable_or_temporary).to eq(false)
-    end
-  end
-
-  describe '#is_complainer_or_fraud_risk' do
-    it 'exposes whether the email address has been flagged as fraud or recognized as a complainer' do
-      expect(email_validation.is_complainer_or_fraud_risk).to eq(false)
     end
   end
 

--- a/spec/loqate/email/gateway_spec.rb
+++ b/spec/loqate/email/gateway_spec.rb
@@ -104,36 +104,32 @@ RSpec.describe Loqate::Email::Gateway, vcr: true do
       it 'returns a valid email validation' do
         result = email_gateway.validate(email: 'wilson.silva@gmail.com')
 
-        expect(result.value).to eq(
-          Loqate::Email::EmailValidation.new(
-            response_code: 'Valid',
-            response_message: 'Email address was fully validated',
-            email_address: 'wilson.silva@gmail.com',
-            user_account: 'wilson.silva',
-            domain: 'gmail.com',
-            is_disposable_or_temporary: false,
-            is_complainer_or_fraud_risk: false,
-            duration: 0.007366261
-          )
+        expect(result.value).to have_attributes(
+          class: Loqate::Email::EmailValidation,
+          response_code: 'Valid',
+          response_message: 'Email address was fully validated',
+          email_address: 'wilson.silva@gmail.com',
+          user_account: 'wilson.silva',
+          domain: 'gmail.com',
+          is_disposable_or_temporary: false,
+          duration: an_instance_of(Float)
         )
       end
     end
 
     context 'when only the email domain was validated' do
       it 'returns a partially valid email validation' do
-        result = email_gateway.validate(email: 'contact@wilsonsilva.net')
+        result = email_gateway.validate(email: 'support@google.com')
 
-        expect(result.value).to eq(
-          Loqate::Email::EmailValidation.new(
-            response_code: 'Valid_CatchAll',
-            response_message: 'Mail is routable to the domain but account could not be validated',
-            email_address: 'contact@wilsonsilva.net',
-            user_account: 'contact',
-            domain: 'wilsonsilva.net',
-            is_disposable_or_temporary: false,
-            is_complainer_or_fraud_risk: false,
-            duration: 0.241566504
-          )
+        expect(result.value).to have_attributes(
+          class: Loqate::Email::EmailValidation,
+          response_code: 'Valid_CatchAll',
+          response_message: 'Mail is routable to the domain but account could not be validated',
+          email_address: 'support@google.com',
+          user_account: 'support',
+          domain: 'google.com',
+          is_disposable_or_temporary: false,
+          duration: an_instance_of(Float)
         )
       end
     end
@@ -142,17 +138,15 @@ RSpec.describe Loqate::Email::Gateway, vcr: true do
       it 'returns an invalid email validation' do
         result = email_gateway.validate(email: '404@404.pl')
 
-        expect(result.value).to eq(
-          Loqate::Email::EmailValidation.new(
-            response_code: 'Invalid',
-            response_message: 'Email Address is not valid',
-            email_address: '404@404.pl',
-            user_account: '404',
-            domain: '404.pl',
-            is_disposable_or_temporary: false,
-            is_complainer_or_fraud_risk: false,
-            duration: 0.009907195
-          )
+        expect(result.value).to have_attributes(
+          class: Loqate::Email::EmailValidation,
+          response_code: 'Invalid',
+          response_message: 'Email Address is not valid',
+          email_address: '404@404.pl',
+          user_account: '404',
+          domain: '404.pl',
+          is_disposable_or_temporary: false,
+          duration: an_instance_of(Float)
         )
       end
     end
@@ -161,19 +155,17 @@ RSpec.describe Loqate::Email::Gateway, vcr: true do
   describe '#validate!' do
     context 'when the result is successful' do
       it 'returns the unwrapped result' do
-        email_validation = email_gateway.validate!(email: 'contact@wilsonsilva.net')
+        email_validation = email_gateway.validate!(email: 'support@google.com')
 
-        expect(email_validation).to eq(
-          Loqate::Email::EmailValidation.new(
-            response_code: 'Valid_CatchAll',
-            response_message: 'Mail is routable to the domain but account could not be validated',
-            email_address: 'contact@wilsonsilva.net',
-            user_account: 'contact',
-            domain: 'wilsonsilva.net',
-            is_disposable_or_temporary: false,
-            is_complainer_or_fraud_risk: false,
-            duration: 0.241566504
-          )
+        expect(email_validation).to have_attributes(
+          class: Loqate::Email::EmailValidation,
+          response_code: 'Valid_CatchAll',
+          response_message: 'Mail is routable to the domain but account could not be validated',
+          email_address: 'support@google.com',
+          user_account: 'support',
+          domain: 'google.com',
+          is_disposable_or_temporary: false,
+          duration: an_instance_of(Float)
         )
       end
     end


### PR DESCRIPTION
* Coerce email validation duration attribute to Float

  **NOTE:** In some instances the Loqate API is returning integers, which due to the current strict definition is causing the parsing of the email validation result to fail.

  ```ruby
  [Loqate::Email::EmailValidation.new] 0 (Integer) has invalid type for :duration violates constraints (type?(Float, 0) failed)
  ```

* Remove `is_complainer_or_fraud_risk` from email validations

  **NOTE:** Loqate has removed `is_complainer_or_fraud_risk` from their email validation responses at some point (it's no longer present in their [API documentation](https://www.loqate.com/resources/support/apis/EmailValidation/Interactive/Validate/2/)). Despite this being a breaking changing they haven't incremented their version number, which led me to find this issue live 😞 . 

**UPDATE:** Loqate has re-added the field to the documentation, but only for advising that is no longer used:

  IsComplainerOrFraudRisk | Boolean | False | This field is no longer valid and will always return False
  -- | -- | -- | --


