### PR TITLE
Add non-documented phone number verification IsValid allowed value

### DIFF
--- a/lib/loqate/phone/phone_number_validation.rb
+++ b/lib/loqate/phone/phone_number_validation.rb
@@ -2,7 +2,7 @@ module Loqate
   module Phone
     # Result of a phone number validation.
     class PhoneNumberValidation < Dry::Struct
-      IsValid = Types::Strict::String.enum('Yes', 'No', 'Unknown')
+      IsValid = Types::Strict::String.enum('Yes', 'No', 'Unknown', 'Maybe')
       NumberType = Types::Strict::String.enum('Mobile', 'Landline', 'Voip', 'Unknown')
 
       # The recipient phone number in international format.

--- a/spec/loqate/phone/phone_number_validation_spec.rb
+++ b/spec/loqate/phone/phone_number_validation_spec.rb
@@ -91,22 +91,18 @@ RSpec.describe Loqate::Phone::PhoneNumberValidation do
   end
 
   describe '#valid?' do
+    %w[No Unknown Maybe].each do |validation_result|
+      context "when the validation result is '#{validation_result}'" do
+        subject { described_class.new(attributes.merge(is_valid: validation_result)) }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
     context 'when the validation result is Yes' do
       subject { described_class.new(attributes.merge(is_valid: 'Yes')) }
 
       it { is_expected.to be_valid }
-    end
-
-    context 'when the validation result is No' do
-      subject { described_class.new(attributes.merge(is_valid: 'No')) }
-
-      it { is_expected.not_to be_valid }
-    end
-
-    context 'when the validation result is Unknown' do
-      subject { described_class.new(attributes.merge(is_valid: 'Unknown')) }
-
-      it { is_expected.not_to be_valid }
     end
   end
 end


### PR DESCRIPTION
Loqate does not document that this is an allowed value for this property but it keeps returning responses with this value on it.

```ruby
Dry::Types::ConstraintError: "Maybe" violates constraints (included_in?(["Yes", "No", "Unknown"], "Maybe") failed)
```