### PR TITLE
Handle empty address result

### DIFF
--- a/lib/loqate/address/gateway.rb
+++ b/lib/loqate/address/gateway.rb
@@ -73,6 +73,8 @@ module Loqate
       def retrieve(options)
         response = client.get(RETRIEVE_ENDPOINT, options)
 
+        return Success(nil) if response.items.empty?
+
         response.errors? && build_error_from(response.items.first) || build_detailed_address_from(response.items.first)
       end
 

--- a/spec/fixtures/vcr_cassettes/Loqate_Address_Gateway/_retrieve/when_there_are_no_items/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Loqate_Address_Gateway/_retrieve/when_there_are_no_items/returns_nil.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.addressy.com/Capture/Interactive/Retrieve/v1.00/json3.ws?Id=GB%7CRM%7CA%7C50303802%7CEN&Key=<LOQATE_API_KEY>
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.addressy.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 01 Apr 2025 15:42:16 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '12'
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, pca-source
+      Records:
+      - '0'
+      X-Robots-Tag:
+      - noindex
+      X-Responsebodysize:
+      - '0'
+      Via:
+      - 1.1 google
+      Set-Cookie:
+      - GCLB=CJDS8Km8w7jyjQEQAw; path=/; HttpOnly; expires=Tue, 01-Apr-2025 15:43:16
+        GMT
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"Items":[]}'
+  recorded_at: Tue, 01 Apr 2025 15:42:16 GMT
+recorded_with: VCR 6.3.1

--- a/spec/loqate/address/gateway_spec.rb
+++ b/spec/loqate/address/gateway_spec.rb
@@ -113,6 +113,14 @@ RSpec.describe Loqate::Address::Gateway, vcr: true do
         )
       end
     end
+
+    context 'when there are no items' do
+      it 'returns nil' do
+        result = address_gateway.retrieve(id: 'GB|RM|A|50303802|EN')
+
+        expect(result).to have_attributes(class: Loqate::Result::Success, value: nil)
+      end
+    end
   end
 
   describe '#find!' do


### PR DESCRIPTION
When fetching addresses from this container `gb-rm|3S2_aZUB1H6m_iwEzqI0` we got this address `GB|RM|A|50303802|EN` back. 

When using the Loqate API to retrieve information about this specific address: `GB|RM|A|50303802|EN`, the API returns an empty result.

This PR is concerned with handling retrieval responses with empty results.

I followed the pattern found here:
https://github.com/wilsonsilva/loqate/blob/4a0e740bae84cbe9fa57e8be2a365f56bcc9bbd8/lib/loqate/geocoding/gateway.rb#L148-L154